### PR TITLE
Display gifts in grid

### DIFF
--- a/src/components/GiftItem.tsx
+++ b/src/components/GiftItem.tsx
@@ -10,7 +10,7 @@ interface GiftItemProps {
 const GiftItem: React.FC<GiftItemProps> = ({ gift, isUnlocked }) => {
   return (
     <div
-      className={`flex flex-col justify-between p-5 border rounded-lg shadow-md mb-3 transition-all duration-300 ${
+      className={`flex flex-col justify-between p-5 border rounded-lg shadow-md transition-all duration-300 aspect-square ${
         isUnlocked ? "shadow-lg" : ""
       }`}
       style={{

--- a/src/components/GiftList.tsx
+++ b/src/components/GiftList.tsx
@@ -9,9 +9,8 @@ interface GiftListProps {
 
 const GiftList: React.FC<GiftListProps> = ({ gifts, totalDonated }) => {
   return (
-    <div className="space-y-3">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
       {gifts
-       
         .map((gift) => (
           <GiftItem
             key={gift.sort_order}


### PR DESCRIPTION
## Summary
- make GiftItem a square by using `aspect-square`
- show GiftList items in a responsive grid

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f649b88e08327baf0e785676441c6