### PR TITLE
Fix favicon not loading in production

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,9 @@ const libreBaskerville = Libre_Baskerville({
 export const metadata: Metadata = {
   title: "Lília & Eduardo: Lista de presentes",
   description: "Lista de presentes para o casamento de Lília e Eduardo",
+  icons: {
+    icon: "/icon.png",
+  },
 };
 
 export default function RootLayout({
@@ -20,9 +23,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={libreBaskerville.className}>
-      <head>
-      <link rel="icon" href="/icon.png" />
-      </head>
       <body
       className="family-p"
       style={{


### PR DESCRIPTION
## Summary
- set favicon in metadata
- remove manual link tag

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8ceb30888327b05107e55b565220